### PR TITLE
Fix CA Cert loop

### DIFF
--- a/rootfs/rootfs/etc/rc.d/install-ca-certs
+++ b/rootfs/rootfs/etc/rc.d/install-ca-certs
@@ -5,7 +5,7 @@ BOOT2DOCKER_CERTS_DIR=/var/lib/boot2docker/certs
 CERTS_DIR=/etc/ssl/certs
 CAFILE=${CERTS_DIR}/ca-certificates.crt
 
-for cert in "${BOOT2DOCKER_CERTS_DIR}"/*.pem; do
+for cert in $(ls -1 ${BOOT2DOCKER_CERTS_DIR}); do
 	echo "installing $cert"
 
 	SRC_CERT_FILE=${BOOT2DOCKER_CERTS_DIR}/${cert}


### PR DESCRIPTION
The last change accidentally causes the script to never include new certs, since the loop now returns a full path. This returns the loop back to its formal function.
